### PR TITLE
add textlint filters

### DIFF
--- a/.textlintrc
+++ b/.textlintrc
@@ -2,7 +2,12 @@
   "plugins": [
     "review"
   ],
-  "filters": {},
+  "filters": {
+    "whitelist": {
+      "allow": []
+    },
+    "comments": true
+  },
   "rules": {
     "preset-ja-technical-writing": true
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "textlint": "^8.2.1",
+    "textlint-filter-rule-comments": "^1.2.2",
+    "textlint-filter-rule-whitelist": "^1.1.0",
     "textlint-plugin-review": "^0.3.3",
     "textlint-rule-preset-ja-technical-writing": "^0.1.3"
   }

--- a/src/index.re
+++ b/src/index.re
@@ -22,3 +22,11 @@
  3. Download from GitHub
 
 ホームページは@<tt>{https://reviewml.org/}です。
+
+以下はtextlintの設定テストです。
+
+#@# textlint-disable
+
+この行は行末に読点がありませんが、textlint-disableになっているため検査に通過します
+
+#@# textlint-enable

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,6 +227,13 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
+clone-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/clone-regexp/-/clone-regexp-1.0.0.tgz#eae0a2413f55c0942f818c229fefce845d7f3b1c"
+  dependencies:
+    is-regexp "^1.0.0"
+    is-supported-regexp-flag "^1.0.0"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -336,13 +343,19 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
-escape-string-regexp@^1.0.2:
+escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
+
+execall@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/execall/-/execall-1.0.0.tgz#73d0904e395b3cab0658b08d09ec25307f29bb73"
+  dependencies:
+    clone-regexp "^1.0.0"
 
 extend@^3.0.0:
   version "3.0.1"
@@ -552,6 +565,14 @@ is-regex@^1.0.4:
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
     has "^1.0.1"
+
+is-regexp@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+
+is-supported-regexp-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.0.tgz#8b520c85fae7a253382d4b02652e045576e13bb8"
 
 is-symbol@^1.0.1:
   version "1.0.1"
@@ -1029,6 +1050,10 @@ state-toggle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
 
+str-to-regexp@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/str-to-regexp/-/str-to-regexp-1.1.3.tgz#26744e999b13979d16210be4bb66bd1d71b4957d"
+
 string-width@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
@@ -1113,6 +1138,18 @@ text-table@^0.2.0:
 textlint-ast-test@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/textlint-ast-test/-/textlint-ast-test-1.1.4.tgz#2655c72e155f3c843937c4a8adc87352116beebe"
+
+textlint-filter-rule-comments@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/textlint-filter-rule-comments/-/textlint-filter-rule-comments-1.2.2.tgz#3a72c494994e068e0e4aaad0f24ea7cfe338503a"
+
+textlint-filter-rule-whitelist@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/textlint-filter-rule-whitelist/-/textlint-filter-rule-whitelist-1.1.0.tgz#8a5379fe7fd102df19a18c62062c994d866fd759"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    execall "^1.0.0"
+    str-to-regexp "^1.1.3"
 
 textlint-formatter@^1.7.3:
   version "1.8.0"


### PR DESCRIPTION
[textlint-filter-rule-comments](https://github.com/textlint/textlint-filter-rule-comments/blob/master/src/parse-comment.js)と[textlint-filter-rule-whitelist](https://github.com/textlint/textlint-filter-rule-whitelist/tree/a826e612454ffcd536b8cee29707517b842622a1)を追加した。
whitelistの方は半角ｶﾅルールで`allow: ["ｶﾅ"]`を指定するなどして試したが、うまく動かなかったので諦めた。