### PR TITLE
Fix GitHub pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ Run commands at project root.
 - `./bin/html` for create html pages.
   - creates `docs/*.html`
   - [GitHub Pages](https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/) Available
+  - (using Re:VIEW deprecated feature)
 - `./bin/review` for check textlint.

--- a/bin/html
+++ b/bin/html
@@ -1,7 +1,7 @@
 #!/bin/sh
 rm docs/*.html
 docker-compose run --rm review bash -c "
-review-index -a --html > index.html
+review-index -a --html | sed -e 's/a name/a href/g' > index.html
 ls *.re | sed 's/\.re$//' | xargs -i bash -c 'review-compile --target html {}.re > {}.html'
 "
 mv src/*.html docs

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <ul class="book-toc">
-<li><a name="./chapter01.html">1 はじめてのRe:VIEW</a></li>
+<li><a href="./chapter01.html">1 はじめてのRe:VIEW</a></li>
 <ol>
 <li>Re:VIEWとは</li>
 </ol>


### PR DESCRIPTION
aタグがname属性になっておりリンクになっていなかった。
`review-index --html`自体がdeprecatedなので利用すること自体望ましくなさそうだが、とりあえず`sed`で置き換えてそれっぽくなるようにした。