### PR TITLE
コンテナ外でコマンドを発行しないようにした

### DIFF
--- a/bin/epub
+++ b/bin/epub
@@ -1,5 +1,2 @@
 #!/bin/sh
-docker-compose run --rm review review-epubmaker config.yml
-if [ -f src/book.epub ]; then
-  mv src/book.epub dists
-fi
+docker-compose run --rm review bash -c "review-epubmaker config.yml && mv book.epub ../dists"

--- a/bin/html
+++ b/bin/html
@@ -1,5 +1,7 @@
 #!/bin/sh
-rm -rf docs/*
-docker-compose run --rm review review-webmaker config.yml
-mv src/webroot/* docs
-rm -rf src/webroot
+docker-compose run --rm review bash -c "
+rm -rf ../docs/*
+review-webmaker config.yml
+mv webroot/* ../docs
+rm -rf webroot
+"

--- a/bin/pdf
+++ b/bin/pdf
@@ -1,5 +1,2 @@
 #!/bin/sh
-docker-compose run --rm review review-pdfmaker config.yml
-if [ -f src/book.pdf ]; then
-  mv src/book.pdf dists
-fi
+docker-compose run --rm review bash -c "review-pdfmaker config.yml && mv book.pdf ../dists"


### PR DESCRIPTION
コンテナ外で必要なコマンドがdocker-composeのみになるようにし、実行環境への依存を最小限にした。