### PR TITLE
reviewdogのトークンがない場合に、エラーが出ないようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,14 @@ jobs:
           command: "curl -fSL https://github.com/haya14busa/reviewdog/releases/download/$REVIEWDOG_VERSION/reviewdog_linux_amd64 -o reviewdog && chmod +x ./reviewdog"
       - run:
           name: lint
-          command: "$(npm bin)/textlint -f checkstyle src/*.re | ./reviewdog -f=checkstyle -name=textlint -ci=circle-ci"
+          command: "$(npm bin)/textlint -f checkstyle src/*.re | tee check_result"
+      - run:
+          name: reviewdog
+          command: >
+              if [ -n "$REVIEWDOG_GITHUB_API_TOKEN" ]; then
+                cat check_result | ./reviewdog -f=checkstyle -name=textlint -ci=circle-ci
+              fi
+          when: on_fail
       - run:
           name: build artifacts
           command: "cd src && review-pdfmaker config.yml && review-epubmaker config.yml && review-webmaker config.yml"


### PR DESCRIPTION
https://circleci.com/gh/kokuyouwind/review-scaffold/66
```
#!/bin/bash -eo pipefail
$(npm bin)/textlint -f checkstyle src/*.re | ./reviewdog -f=checkstyle -name=textlint -ci=circle-ci
REVIEWDOG_GITHUB_API_TOKEN is not set
Exited with code 1
```
というエラーが表示されてしまうので、トークンがないときはreviewdogを起動しないようにする。

修正後は以下のようになる。

https://circleci.com/gh/kokuyouwind/review-scaffold/68
```
#!/bin/bash -eo pipefail
$(npm bin)/textlint -f checkstyle src/*.re | tee check_result
<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="/root/project/src/chapter01.re"><error line="28" column="33" severity="error" message="文末が&quot;。&quot;で終わっていません。 (preset-ja-technical-writing/ja-no-mixed-period)" source="eslint.rules.preset-ja-technical-writing/ja-no-mixed-period" /></file></checkstyle>
Exited with code 1
```